### PR TITLE
Rework NMEA output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(sw_sensor_algorithms)
 set(SOURCE_FILES
     Generic_Algorithms/ascii_support.cpp
     Generic_Algorithms/serial_io.cpp
+
     NAV_Algorithms/AHRS.cpp
     NAV_Algorithms/air_density_observer.cpp
     NAV_Algorithms/atmosphere.cpp
@@ -11,8 +12,10 @@ set(SOURCE_FILES
     NAV_Algorithms/KalmanVario_PVA.cpp
     NAV_Algorithms/navigator.cpp
     NAV_Algorithms/persistent_data.cpp
+
     Output_Formatter/CAN_output.cpp
     Output_Formatter/NMEA_format.cpp
+    Output_Formatter/system_state.h
 )
 
 set(HEADER_FILES
@@ -32,6 +35,7 @@ set(HEADER_FILES
     Generic_Algorithms/serial_io.h
     Generic_Algorithms/trigger.h
     Generic_Algorithms/vector.h
+
     NAV_Algorithms/AHRS.h
     NAV_Algorithms/air_density_observer.h
     NAV_Algorithms/atmosphere.h
@@ -47,6 +51,7 @@ set(HEADER_FILES
     NAV_Algorithms/persistent_data.h
     NAV_Algorithms/soaring_flight_averager.h
     NAV_Algorithms/windobserver.h
+
     Output_Formatter/CAN_output.h
     Output_Formatter/generic_CAN_driver.h
     Output_Formatter/NMEA_format.h

--- a/Output_Formatter/CAN_output.cpp
+++ b/Output_Formatter/CAN_output.cpp
@@ -47,6 +47,7 @@ enum CAN_ID_SENSOR
 
 void CAN_output ( const output_data_t &x)
 {
+#ifndef __MSVC__
   CANpacket p;
 
   p.id=c_CAN_Id_EulerAngles;		// 0x101
@@ -137,7 +138,7 @@ void CAN_output ( const output_data_t &x)
   p.data_sh[0] = (int16_t)(round(x.slip_angle * 1000.0f));	// slip angle in radiant from body acceleration
   p.data_sh[1] = (int16_t)(round(x.turn_rate  * 1000.0f)); 	// turn rate rad/s
   p.data_sh[2] = (int16_t)(round(x.nick_angle * 1000.0f));	// nick angle in radiant from body acceleration
-  if( CAN_send(p, 1)) // check CAN for timeout this time
+  if (CAN_send(p, 1)) // check CAN for timeout this time
     system_state |= CAN_OUTPUT_ACTIVE;
   else
     system_state &= ~CAN_OUTPUT_ACTIVE;
@@ -146,4 +147,5 @@ void CAN_output ( const output_data_t &x)
   p.dlc=4;
   p.data_w[0] = system_state;
   CAN_send(p, 1);
+#endif
 }

--- a/Output_Formatter/NMEA_format.cpp
+++ b/Output_Formatter/NMEA_format.cpp
@@ -278,7 +278,8 @@ char *format_MWV ( float wind_north, float wind_east, char *p)
   return p;
 }
 
-ROM char HCHDT[]="$HCHDT,";
+#if USE_MWV
+ROM char HCHDT[] = "$HCHDT,";
 
 //! create HCHDM sentence to report true heading
 void format_HCHDT( float true_heading, char *p) // report magnetic heading
@@ -294,6 +295,7 @@ void format_HCHDT( float true_heading, char *p) // report magnetic heading
 
   *p = 0;
 }
+#endif  // USE_MWV
 
 // ********* Larus-specific protocols *************************************
 #if USE_LARUS_NMEA_EXTENSIONS
@@ -314,14 +316,14 @@ void format_PLARA ( float roll, float nick, float yaw, char *p)
     p = append_string( p, PLARA);
 
     p = integer_to_ascii_1_decimal( round(roll * RAD_TO_DEGREE_10), p);
+    *p++ = ',';
 
-    p = append_string( p, ",");
     p = integer_to_ascii_1_decimal( round(nick * RAD_TO_DEGREE_10), p);
+    *p++ = ',';
 
     if( yaw < 0.0f)
         yaw += 6.2832f;
-    p = append_string( p, ",");
-    p = integer_to_ascii_1_decimal( round(yaw * RAD_TO_DEGREE_10), p);
+    p = integer_to_ascii_1_decimal(round(yaw * RAD_TO_DEGREE_10), p);
 
     *p = 0;
 }
@@ -336,16 +338,16 @@ char *format_PLARV(float vario, float avg_vario, float altitude, float TAS,
   p = append_string(p, PLARV);
 
   p = integer_to_ascii_1_decimal(round(vario * 10.0f), p); // in m/s
-  p = append_string(p, ",M,");
+  *p++ = ',';
 
   p = integer_to_ascii_1_decimal(round(avg_vario * 10.0f), p); // in m/s
-  p = append_string(p, ",M,");
+  *p++ = ',';
 
   p = format_integer(altitude, p); // in m
-  p = append_string(p, ",M,");
+  *p++ = ',';
 
   p = integer_to_ascii_1_decimal(round(TAS * MPS_TO_KMPH * 10.0f), p); // in m/s
-  p = append_string(p, ",K");
+  *p = 0;
 
   return p;
 }
@@ -368,11 +370,11 @@ void format_PLARW ( float wind_north, float wind_east, char windtype, char *p)
     if( angle < 0)
         angle += 360;
     p=format_integer( angle, p);
-    p = append_string( p, ",T,");
+    *p++ = ',';
 
     int speed = round( MPS_TO_KMPH * SQRT( SQR( wind_north) + SQR( wind_east)));
     p=format_integer( speed, p);
-    p = append_string( p, ",K,");
+    *p++ = ',';
 
     *p++ = windtype;
 
@@ -437,10 +439,9 @@ void format_NMEA_string( const output_data_t &output_data, string_buffer_t &NMEA
 #endif
 
   format_HCHDT( output_data.euler.y, next);
-  next = NMEA_append_tail (next);
+  next = NMEA_append_tail(next);
 
 #if USE_LARUS_NMEA_EXTENSIONS
-
   // instant wind
   format_PLARW (output_data.wind.e[NORTH], output_data.wind.e[EAST], 'I', next);
   next = NMEA_append_tail (next);

--- a/Output_Formatter/NMEA_format.cpp
+++ b/Output_Formatter/NMEA_format.cpp
@@ -27,6 +27,7 @@
 #include "embedded_math.h"
 
 #define USE_MWV		1
+#define USE_PLARD	0
 
 #define ANGLE_SCALE 1e-7f
 #define MPS_TO_NMPH 1.944f // 90 * 60 NM / 10000km * 3600 s/h
@@ -328,6 +329,18 @@ void format_PLARA ( float roll, float nick, float yaw, char *p)
     *p = 0;
 }
 
+#if USE_PLARD
+ROM char PLARD[] = "$PLARD,";
+
+void format_PLARD(float air_density, char *p) {
+  p = append_string(p, PLARD);
+  // Instant air density in g/m^3.
+  p = integer_to_ascii_1_decimal(round(air_density * 10000.0f), p);
+  p = append_string(p, ",A"); // always report "valid" for the moment
+  *p = 0;
+}
+#endif  // USE_PLARD
+
 ROM char PLARV[] = "$PLARV,";
 
 char *format_PLARV(float vario, float avg_vario, float altitude, float TAS,
@@ -457,6 +470,12 @@ void format_NMEA_string( const output_data_t &output_data, string_buffer_t &NMEA
   // battery_voltage
   format_PLARB( output_data.m.supply_voltage, next);
   next = NMEA_append_tail(next);
+
+#if USE_PLARD
+  // air_density
+  format_PLARD(output_data.air_density, next);
+  next = NMEA_append_tail(next);
+#endif // USE_PLARD
 
   // report instant and average total-energy-compensated variometer, pressure
   // altitude, TAS

--- a/Output_Formatter/system_state.h
+++ b/Output_Formatter/system_state.h
@@ -32,12 +32,16 @@ extern uint32_t system_state; //!< bits collected from availability_bits
 
 inline void update_system_state_set( unsigned value)
 {
-	__atomic_or_fetch ( &system_state, value, __ATOMIC_ACQUIRE);
+#ifndef __MSVC__
+  __atomic_or_fetch ( &system_state, value, __ATOMIC_ACQUIRE);
+#endif
 }
 
 inline void update_system_state_clear( unsigned value)
 {
-	__atomic_and_fetch ( &system_state, ~value, __ATOMIC_ACQUIRE);
+#ifndef __MSVC__
+  	__atomic_and_fetch ( &system_state, ~value, __ATOMIC_ACQUIRE);
+#endif
 }
 
 #endif /* INC_SYSTEM_STATE_H_ */


### PR DESCRIPTION
I did some changes for the NMEA output - in my opinion it is easier to create in Larus and better to parse in XCSoar/OpenSoar:
* Removed strange $PTAS1 and POV (this isn't necessary anymore)
* Removed all unnecessary units
* Hide the CAN-Output in MSVC - here is unused

All changes I have checked in the new Larus driver parser, so it does work perfectly...
Later we should define the frequency of all different sentences: not every sentence is necessary to send in 200ms steps!