### PR TITLE
Git Tag Version via CAN Output preparation

### DIFF
--- a/Output_Formatter/CAN_output.cpp
+++ b/Output_Formatter/CAN_output.cpp
@@ -149,8 +149,13 @@ void CAN_output ( const output_data_t &x)
   else
     system_state &= ~CAN_OUTPUT_ACTIVE;
 
+#ifndef GIT_TAG_DEC
+#define GIT_TAG_DEC 0xffffffff
+#endif
+  
   p.id=c_CAN_Id_SystemState;				// 0x10d
-  p.dlc=4;
+  p.dlc=8;
   p.data_w[0] = system_state;
+  p.data_w[1] = GIT_TAG_DEC;
   CAN_send(p, 1);
 }


### PR DESCRIPTION
prepared CAN_output.cpp to send via GIT TAG generated version information. 
This sw_sensor_algorithms change is required in order to implement the feature in the sensor software.
