### PR TITLE
Add PLARI NMEA sentence for Indicated Airspeed (IAS)

### DIFF
--- a/Output_Formatter/NMEA_format.cpp
+++ b/Output_Formatter/NMEA_format.cpp
@@ -307,6 +307,24 @@ void format_PLARV ( float variometer, float avg_variometer, float pressure_altit
   p = NMEA_append_tail ( line_start);
 }
 
+ROM char PLARI[]="$PLARI,";
+
+//! Indicated Airspeed (IAS) in km/h
+void format_PLARI ( float IAS, char * &p)
+{
+    char * line_start = p;
+    append_string( p, PLARI);
+
+    // Clipping to realistic values for a glider
+    IAS = CLIP<float>(IAS, 0, 100);
+
+    // Output IAS in km/h with one decimal
+    to_ascii_n_decimals( IAS * MPS_TO_KMPH, 1, p);
+
+    p = NMEA_append_tail ( line_start);
+}
+
+
 ROM char PLARS[]="$PLARS,L,";
 ROM char PLARS_MC[]="MC,";
 ROM char PLARS_BAL[]="BAL,";
@@ -404,6 +422,9 @@ void format_NMEA_string_fast( const output_data_t &output_data, string_buffer_t 
 
   // instant wind
   format_PLARW (output_data.wind[NORTH], output_data.wind[EAST], 'I', next);
+
+  // NEW: Indicated Airspeed (IAS)
+  format_PLARI (output_data.IAS, next);
 
 //  assert(   next - NMEA_buf.string < string_buffer_t::BUFLEN);
   NMEA_buf.length = next - NMEA_buf.string;

--- a/Output_Formatter/NMEA_format.h
+++ b/Output_Formatter/NMEA_format.h
@@ -1,8 +1,9 @@
 /** ***********************************************************************
- * @file		NMEA_format.h
- * @brief		converters for NMEA string output
- * @author		Dr. Klaus Schaefer
- **************************************************************************/
+* @fileNMEA_format.h
+* @briefconverters for NMEA string output
+* @authorDr. Klaus Schaefer
+* @modifiedIAS support added (PLARI sentence)
+**************************************************************************/
 #ifndef APPLICATION_NMEA_FORMAT_H_
 #define APPLICATION_NMEA_FORMAT_H_
 
@@ -13,17 +14,17 @@
 class string_buffer_t
 {
 public:
-  enum{ BUFLEN = 1024-sizeof(uint32_t)};
-  char string[BUFLEN];
-  uint32_t length;
+enum{ BUFLEN = 1024-sizeof(uint32_t)};
+char string[BUFLEN];
+uint32_t length;
 };
 
 enum PLARS_TYPES{
-  MC = 0,
-  BAL,
-  BUGS,
-  QNH,
-  CIR
+MC = 0,
+BAL,
+BUGS,
+QNH,
+CIR
 };
 
 //! combine all data to be output to the NMEA port
@@ -31,6 +32,7 @@ void format_NMEA_string_fast( const output_data_t &output_data, string_buffer_t 
 void format_NMEA_string_slow( const output_data_t &output_data, string_buffer_t &NMEA_buf);
 void to_ascii_n_decimals( float value, unsigned decimals, char * &s);
 void format_PLARV ( float variometer, float avg_variometer, float pressure_altitude, float TAS, char * &p);
+void format_PLARI ( float IAS, char * &p);  // NEW: IAS sentence
 void format_RMC (const coordinates_t &coordinates, char * &p);
 void format_PLARS ( float value, PLARS_TYPES type, char * &p) ;
 bool NMEA_checksum( const char *line);


### PR DESCRIPTION
## Summary
This PR adds a new NMEA sentence `$PLARI` to output Indicated Airspeed (IAS) in km/h.

## Changes
- Added `format_PLARI()` function in `NMEA_format.cpp`
- Added function declaration in `NMEA_format.h`
- Integrated into `format_NMEA_string_fast()` output

## NMEA Format
```
$PLARI,xxx.x*hh<CR><LF>
```
- Field 1: IAS in km/h (one decimal)
- Field 2: Checksum

## Purpose
Enables glide computers (like OpenSoar/XCSoar) to receive and display IAS from Larus Varion.