### PR TITLE
feat: add GNSS accuracy and heading exchange over CAN

### DIFF
--- a/NAV_Algorithms/GNSS.h
+++ b/NAV_Algorithms/GNSS.h
@@ -156,6 +156,11 @@ typedef struct
 
   float3vector relPosNED;	//!< vector from primary to secondary GNSS antenna
   float relPosHeading;		//!< heading from D-GNSS
+  float relPosAccN;		//!< D-GNSS baseline accuracy North / m
+  float relPosAccE;		//!< D-GNSS baseline accuracy East / m
+  float relPosAccD;		//!< D-GNSS baseline accuracy Down / m
+  float relPosAccLen;		//!< D-GNSS baseline length accuracy / m
+  float relPosHeadingAcc;	//!< D-GNSS heading accuracy / rad
 } D_GNSS_coordinates_t;
 
 //! Contains all important data from the GNSS

--- a/NAV_Algorithms/GNSS.h
+++ b/NAV_Algorithms/GNSS.h
@@ -155,6 +155,7 @@ typedef struct
   uint16_t pDOP;		//!< Position dilution of precision 0.01 units
 
   float3vector relPosNED;	//!< vector from primary to secondary GNSS antenna
+  float relPosLength;		//!< D-GNSS baseline length / m
   float relPosHeading;		//!< heading from D-GNSS
   float relPosAccN;		//!< D-GNSS baseline accuracy North / m
   float relPosAccE;		//!< D-GNSS baseline accuracy East / m

--- a/Output_Formatter/CAN_output.cpp
+++ b/Output_Formatter/CAN_output.cpp
@@ -57,6 +57,8 @@ enum CAN_ID_SENSOR
   CAN_Id_GPS_Alt	= 0x143,    //!< float MSL altitude, float geo separation
   CAN_Id_GPS_Trk_Spd	= 0x144,    //!< float ground track, float groundspeed / m/s
   CAN_Id_GPS_Sats	= 0x145,    //!< uin8_t No of Sats, (uint8_t)bool SAT FIX type
+  CAN_Id_GPS_Accuracy	= 0x146,    //!< float horizontal accuracy length / m, float heading accuracy / rad
+  CAN_Id_GPS_Heading	= 0x147,    //!< float D-GNSS heading / rad
 
   CAN_Id_Heartbeat_Sens	= 0x520,
   CAN_Id_Identify_Sensor = 0x521,
@@ -181,6 +183,17 @@ void CAN_output ( const measurement_data_t &m, const D_GNSS_coordinates_t &c, st
   p.dlc=2;
   p.data_b[0] = c.SATS_number;
   p.data_b[1] = c.sat_fix_type;
+  CAN_send(p, 1);
+
+  p.id=CAN_Id_GPS_Accuracy;
+  p.dlc=8;
+  p.data_f[0] = c.relPosAccLen;
+  p.data_f[1] = c.relPosHeadingAcc;
+  CAN_send(p, 1);
+
+  p.id=CAN_Id_GPS_Heading;
+  p.dlc=4;
+  p.data_f[0] = c.relPosHeading;
   CAN_send(p, 1);
 
   p.id=CAN_Id_SystemState;

--- a/Output_Formatter/CAN_output.cpp
+++ b/Output_Formatter/CAN_output.cpp
@@ -59,6 +59,8 @@ enum CAN_ID_SENSOR
   CAN_Id_GPS_Sats	= 0x145,    //!< uin8_t No of Sats, (uint8_t)bool SAT FIX type
   CAN_Id_GPS_Accuracy	= 0x146,    //!< float horizontal accuracy length / m, float heading accuracy / rad
   CAN_Id_GPS_Heading	= 0x147,    //!< float D-GNSS heading / rad
+  CAN_Id_GPS_RelPos_NE	= 0x148,    //!< float D-GNSS relPosN, float relPosE / m
+  CAN_Id_GPS_RelPos_D_Length = 0x149, //!< float D-GNSS relPosD, float relPosLength / m
 
   CAN_Id_Heartbeat_Sens	= 0x520,
   CAN_Id_Identify_Sensor = 0x521,
@@ -196,6 +198,18 @@ void CAN_output ( const measurement_data_t &m, const D_GNSS_coordinates_t &c, st
   p.data_f[0] = c.relPosHeading;
   CAN_send(p, 1);
 
+  p.id=CAN_Id_GPS_RelPos_NE;
+  p.dlc=8;
+  p.data_f[0] = c.relPosNED[NORTH];
+  p.data_f[1] = c.relPosNED[EAST];
+  CAN_send(p, 1);
+
+  p.id=CAN_Id_GPS_RelPos_D_Length;
+  p.dlc=8;
+  p.data_f[0] = c.relPosNED[DOWN];
+  p.data_f[1] = c.relPosLength;
+  CAN_send(p, 1);
+
   p.id=CAN_Id_SystemState;
   p.dlc=8;
   p.data_w[0] = system_state;
@@ -225,4 +239,3 @@ void CAN_heartbeat( void)
   p.data_w[1] = UNIQUE_ID[0];
   CAN_send(p, 1);
 }
-


### PR DESCRIPTION
## Summary
This PR adds GNSS accuracy and heading exchange over CAN for the Larus algorithms library.

It introduces the required accuracy fields in the GNSS coordinate data structures and forwards them on the CAN output side.

## Changes
- extend `NAV_Algorithms/GNSS.h` with the GNSS accuracy-related fields needed by the sensor/frontend exchange
- extend `Output_Formatter/CAN_output.cpp` to publish the GNSS accuracy values via CAN

## Why
The goal is to make the GNSS accuracy information available over the CAN interface for visualization/debugging in the frontend.

## Scope
Included:
- GNSS structure changes needed for CAN exchange
- CAN output changes for GNSS accuracy

## Files
- `NAV_Algorithms/GNSS.h`
- `Output_Formatter/CAN_output.cpp`

## Note:
Update of values in sw_sensor will be introduced by a PR in this repo.